### PR TITLE
Updated command to build from source

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,10 @@ Technical Details
 
 Building From Source
 --------------------
-To build from source, issue this command from the top-level directory of your repository:
+To build from source, issue this command from the /source directory of your repository:
 
 <pre>
-	./source/Scripts/framework.sh
+	./Scripts/framework.sh
 </pre>
 
 


### PR DESCRIPTION
Running ./source/Scripts/framework.sh from the top-level dir does not work. Instead framework.sh requires the user to run ./Scripts/framework.sh from /source.
