### PR TITLE
Updated addURLTerm

### DIFF
--- a/source/Classes/AppServices/ApigeeQuery.m
+++ b/source/Classes/AppServices/ApigeeQuery.m
@@ -121,6 +121,9 @@ static NSString* kEntityTypeKey = @"type";
     {
         // we already have some terms. Append an & before continuing
         [m_urlTerms appendFormat:@"&"];
+    } else {
+        // append ql= to start the query string
+        [m_urlTerms appendFormat:@"ql="];
     }
     [m_urlTerms appendFormat:@"%@=%@", escapedUrlTerm, escapedEquals];
 }


### PR DESCRIPTION
Updated addURLTerm to prepend ql= if no query terms have been set.

Allows the user to just specify key-value pairs in their NSMutableDictionary, rather than having to set a ql key.
