### PR TITLE
USERGRID-2668: added try/catch block in populateWithError; added try/cat...

### DIFF
--- a/source/Classes/Models/ApigeeNetworkEntry.m
+++ b/source/Classes/Models/ApigeeNetworkEntry.m
@@ -116,21 +116,15 @@ static NSString *kHeaderServerId       = @"x-apigee-serverid";
 - (void)populateWithError:(NSError*)error
 {
     if (error) {
-        BOOL treatAsError = NO;
-        
-        // the following check on class type should not be necessary, but
-        // we're doing it as a safeguard as there have been some strange
-        // edge cases where a string (NSString*) is passed in.
-        if ([error isKindOfClass:[NSError class]]) {
+        @try {
             self.transactionDetails = [error localizedDescription];
-            treatAsError = YES;
-        } else if ([error isKindOfClass:[NSString class]]) {
-            self.transactionDetails = (NSString*) error;
-            treatAsError = YES;
-        }
-        
-        if (treatAsError) {
             self.numErrors = @"1";
+        }
+        @catch (NSException *exception)
+        {
+            ApigeeLogWarn(@"MONITOR_CLIENT",
+                          @"unable to capture potential networking error: %@",
+                          [exception reason]);
         }
     }
 }


### PR DESCRIPTION
...ch in swizzled sendSynchronousRequest; also added code to capture NSError in sendSynchronousRequest, even if caller passed NULL.
