### PR TITLE
USERGRID-2560: changed timing of network calls to use mach time (mach_ab...

### DIFF
--- a/source/Classes/Models/ApigeeNetworkEntry.h
+++ b/source/Classes/Models/ApigeeNetworkEntry.h
@@ -27,6 +27,11 @@
 @property (strong) NSString *domain;
 //@property (strong) NSNumber *allowsCellularAccess;
 
++ (uint64_t)machTime;
++ (CGFloat)millisFromMachStartTime:(uint64_t)startTime endTime:(uint64_t)endTime;
++ (CGFloat)secondsFromMachStartTime:(uint64_t)startTime endTime:(uint64_t)endTime;
++ (NSDate*)machTimeToDate:(uint64_t)machTime;
+
 - (id)init;
 
 - (NSDictionary*) asDictionary;
@@ -38,7 +43,7 @@
 - (void)populateWithResponseData:(NSData*)responseData;
 - (void)populateWithResponseDataSize:(NSUInteger)dataSize;
 - (void)populateWithError:(NSError*)error;
-- (void)populateStartTime:(NSDate*)started ended:(NSDate*)ended;
+- (void)populateStartTime:(uint64_t)started ended:(uint64_t)ended;
 
 - (void)debugPrint;
 

--- a/source/Classes/Services/ApigeeFunctions.m
+++ b/source/Classes/Services/ApigeeFunctions.m
@@ -170,8 +170,6 @@ void Apigee_record_server_response_metrics(const server_response_metrics *metric
     }
     
     // next, convert data types for Objective-C
-    NSDate *startTime = [monitoringClient machTimeToDate:metrics->start_time];
-    NSDate *endTime = [monitoringClient machTimeToDate:metrics->end_time];
     NSString *url;
     
     if (have_non_empty_string_value(metrics->url)) {
@@ -199,7 +197,7 @@ void Apigee_record_server_response_metrics(const server_response_metrics *metric
 
     ApigeeNetworkEntry *entry = [[ApigeeNetworkEntry alloc] init];
     [entry populateWithURLString:url];
-    [entry populateStartTime:startTime ended:endTime];
+    [entry populateStartTime:metrics->start_time ended:metrics->end_time];
     
     if (metrics->http_status_code > 0) {
         entry.httpStatusCode = [NSString stringWithFormat:@"%d",

--- a/source/Classes/Services/ApigeeMonitoringClient.h
+++ b/source/Classes/Services/ApigeeMonitoringClient.h
@@ -205,8 +205,8 @@
  @return boolean indicating whether the recording was made or not
  */
 - (BOOL)recordNetworkSuccessForUrl:(NSString*)url
-                         startTime:(NSDate*)startTime
-                           endTime:(NSDate*)endTime;
+                         startTime:(uint64_t)startTime
+                           endTime:(uint64_t)endTime;
 
 /*!
  @abstract Records a failed network call.
@@ -217,8 +217,8 @@
  @return boolean indicating whether the recording was made or not
  */
 - (BOOL)recordNetworkFailureForUrl:(NSString*)url
-                         startTime:(NSDate*)startTime
-                           endTime:(NSDate*)endTime
+                         startTime:(uint64_t)startTime
+                           endTime:(uint64_t)endTime
                              error:(NSString*)errorDescription;
 
 /*!
@@ -319,7 +319,7 @@
 /*!
  @internal
  */
-- (void)setStartTime:(NSDate*)startTime
+- (void)setStartTime:(uint64_t)startTime
   forSessionDataTask:(NSURLSessionDataTask*)dataTask;
 
 #endif

--- a/source/Classes/Services/ApigeeMonitoringClient.m
+++ b/source/Classes/Services/ApigeeMonitoringClient.m
@@ -714,8 +714,8 @@ static bool AmIBeingDebugged(void)
         
         if (self.showDebuggingInfo) {
             NSString* debugMsg =
-            [NSString stringWithFormat:@"configuration sampling rate=%d",
-             self.activeSettings.samplingRate];
+            [NSString stringWithFormat:@"configuration sampling rate=%ld",
+             (long)self.activeSettings.samplingRate];
             [self printDebugMessage:debugMsg];
             debugMsg = [NSString stringWithFormat:@"coin flip result = %d",
                         r];
@@ -884,7 +884,7 @@ static bool AmIBeingDebugged(void)
     }
     
     NSData* postData = [postBody dataUsingEncoding:NSUTF8StringEncoding];
-    NSString* postLength = [NSString stringWithFormat:@"%d", [postData length]];
+    NSString* postLength = [NSString stringWithFormat:@"%lu", (unsigned long)[postData length]];
     
     [request setValue:postLength forHTTPHeaderField:@"Content-Length"];
     
@@ -936,7 +936,7 @@ static bool AmIBeingDebugged(void)
     }
     
     NSData* postData = [postBody dataUsingEncoding:NSUTF8StringEncoding];
-    NSString* postLength = [NSString stringWithFormat:@"%d", [postData length]];
+    NSString* postLength = [NSString stringWithFormat:@"%lu", (unsigned long)[postData length]];
     
     [request setValue:postLength forHTTPHeaderField:@"Content-Length"];
     
@@ -1576,8 +1576,8 @@ static bool AmIBeingDebugged(void)
 }
 
 - (BOOL)recordNetworkSuccessForUrl:(NSString*)url
-                         startTime:(NSDate*)startTime
-                           endTime:(NSDate*)endTime
+                         startTime:(uint64_t)startTime
+                           endTime:(uint64_t)endTime
 {
     BOOL metricsRecorded = NO;
     
@@ -1598,8 +1598,8 @@ static bool AmIBeingDebugged(void)
 }
 
 - (BOOL)recordNetworkFailureForUrl:(NSString*)url
-                         startTime:(NSDate*)startTime
-                           endTime:(NSDate*)endTime
+                         startTime:(uint64_t)startTime
+                           endTime:(uint64_t)endTime
                              error:(NSString*)errorDescription
 {
     BOOL metricsRecorded = NO;
@@ -1769,7 +1769,7 @@ static bool AmIBeingDebugged(void)
     }
 }
 
-- (void)setStartTime:(NSDate*)startTime forSessionDataTask:(NSURLSessionDataTask*)dataTask
+- (void)setStartTime:(uint64_t)startTime forSessionDataTask:(NSURLSessionDataTask*)dataTask
 {
     if (self.isInitialized) {
         if( startTime && dataTask )

--- a/source/Classes/Services/ApigeeNSURLConnectionDataDelegateInterceptor.h
+++ b/source/Classes/Services/ApigeeNSURLConnectionDataDelegateInterceptor.h
@@ -15,7 +15,7 @@
 }
 
 
-@property(strong) NSDate *createTime;
+@property (assign) uint64_t createTime;
 
 - (id) initAndInterceptFor:(id) target withRequest:(NSURLRequest*)request;
 

--- a/source/Classes/Services/ApigeeNSURLConnectionDataDelegateInterceptor.m
+++ b/source/Classes/Services/ApigeeNSURLConnectionDataDelegateInterceptor.m
@@ -42,7 +42,7 @@
     
     if (self) {
         self.target = target;
-        self.createTime = [NSDate date];
+        self.createTime = [ApigeeNetworkEntry machTime];
         self.dataSize = 0;
         _connectionAlive = YES;
         
@@ -106,13 +106,13 @@
 
     _connectionAlive = NO;
     
-    NSDate *ended = [NSDate date];
+    uint64_t ended = [ApigeeNetworkEntry machTime];
     
     if (self.target && [self.target respondsToSelector:@selector(connection:didFailWithError:)]) {
         [self.target connection:connection didFailWithError:error];
     }
     
-    NSDate *started = [connection startTime];
+    uint64_t started = [connection startTime];
     
     if( ! started )
     {
@@ -273,13 +273,13 @@
 
     _connectionAlive = NO;
 
-    NSDate *ended = [NSDate date];
+    uint64_t ended = [ApigeeNetworkEntry machTime];
     
     if (self.target && [self.target respondsToSelector:@selector(connectionDidFinishLoading:)]) {
         [self.target connectionDidFinishLoading:connection];
     }
     
-    NSDate *started = [connection startTime];
+    uint64_t started = [connection startTime];
 
     if( ! started )
     {

--- a/source/Classes/Services/ApigeeNSURLSessionDataDelegateInterceptor.m
+++ b/source/Classes/Services/ApigeeNSURLSessionDataDelegateInterceptor.m
@@ -185,7 +185,7 @@ didCompleteWithError:(NSError *)error
 {
     //NSLog(@"interceptor URLSession:task:didCompleteWithError:");
     
-    NSDate* endTime = [NSDate date];
+    uint64_t endTime = [ApigeeNetworkEntry machTime];
     
     ApigeeMonitoringClient* monitoringClient =
         [ApigeeMonitoringClient sharedInstance];

--- a/source/Classes/Services/ApigeeNSURLSessionDataTaskInfo.h
+++ b/source/Classes/Services/ApigeeNSURLSessionDataTaskInfo.h
@@ -14,7 +14,7 @@ typedef void (^DataTaskCompletionBlock)(NSData*,NSURLResponse*,NSError*);
 
 @interface ApigeeNSURLSessionDataTaskInfo : NSObject
 
-@property (copy, nonatomic) NSDate* startTime;
+@property (assign, nonatomic) uint64_t startTime;
 @property (strong, nonatomic) NSURLSessionDataTask* sessionDataTask;
 @property (strong, nonatomic) ApigeeNetworkEntry* networkEntry;
 @property (copy, nonatomic) DataTaskCompletionBlock completionHandler;

--- a/source/Classes/Services/ApigeeNSURLSessionDataTaskInfo.m
+++ b/source/Classes/Services/ApigeeNSURLSessionDataTaskInfo.m
@@ -32,7 +32,7 @@
 - (void)debugPrint
 {
     NSLog(@"========= Start ApigeeNSURLSessionDataTaskInfo ======");
-    NSLog(@"startTime=%@", self.startTime);
+    NSLog(@"startTime=%@", [ApigeeNetworkEntry machTimeToDate:self.startTime]);
     NSLog(@"sessionDataTask=%@", self.sessionDataTask);
     if( self.networkEntry )
     {
@@ -43,7 +43,7 @@
         NSLog(@"networkEntry is nil");
     }
     NSLog(@"completionHandler=%@", self.completionHandler);
-    NSLog(@"dataSize=%d", self.dataSize);
+    NSLog(@"dataSize=%lu", (unsigned long)self.dataSize);
     NSLog(@"key=%@", self.key);
     NSLog(@"========= End ApigeeNSURLSessionDataTaskInfo ======");
 }

--- a/source/Classes/Services/ApigeeNSURLSessionSupport.m
+++ b/source/Classes/Services/ApigeeNSURLSessionSupport.m
@@ -55,7 +55,7 @@ static NSURLSession* NSURLSession_apigeeSessionWithConfigurationDelegateAndQueue
 static void NSCFLocalDataTask_apigeeResume(id self, SEL _cmd)
 {
     // set the starting time for this data task
-    NSDate* startTime = [NSDate date];
+    uint64_t startTime = [ApigeeNetworkEntry machTime];
     ApigeeMonitoringClient* monitoringClient = [ApigeeMonitoringClient sharedInstance];
     [monitoringClient setStartTime:startTime forSessionDataTask:self];
     
@@ -66,7 +66,7 @@ static void NSCFLocalDataTask_apigeeResume(id self, SEL _cmd)
 static void NSURLSessionTask_apigeeResume(id self, SEL _cmd)
 {
     // set the starting time for this data task
-    NSDate* startTime = [NSDate date];
+    uint64_t startTime = [ApigeeNetworkEntry machTime];
     ApigeeMonitoringClient* monitoringClient = [ApigeeMonitoringClient sharedInstance];
     [monitoringClient setStartTime:startTime forSessionDataTask:self];
     
@@ -88,7 +88,7 @@ static NSURLSessionDataTask* NSCFURLSession_apigeeDataTaskWithURLAndCompletionHa
                                                                  NSURLResponse *response,
                                                                  NSError *error) {
             
-            NSDate* endTime = [NSDate date];
+            uint64_t endTime = [ApigeeNetworkEntry machTime];
             
             ApigeeNSURLSessionDataTaskInfo* sessionDataTaskInfo =
             [monitoringClient dataTaskInfoForIdentifier:dataTaskIdentifier];
@@ -146,7 +146,7 @@ static NSURLSessionDataTask* NSCFURLSession_apigeeDataTaskWithRequestAndCompleti
                                                                          NSURLResponse *response,
                                                                          NSError *error) {
             
-            NSDate* endTime = [NSDate date];
+            uint64_t endTime = [ApigeeNetworkEntry machTime];
             
             ApigeeNSURLSessionDataTaskInfo* sessionDataTaskInfo =
             [monitoringClient dataTaskInfoForIdentifier:dataTaskIdentifier];

--- a/source/Classes/Services/ApigeeUIWebViewDelegateInterceptor.m
+++ b/source/Classes/Services/ApigeeUIWebViewDelegateInterceptor.m
@@ -14,7 +14,7 @@
 @interface ApigeeUIWebViewDelegateInterceptor()
 
 @property (weak) id<UIWebViewDelegate> target;
-@property (strong) NSDate *started;
+@property (assign) uint64_t started;
 @property (strong) ApigeeNetworkEntry *networkEntry;
 @end
 
@@ -49,7 +49,7 @@
 
 - (void) webViewDidStartLoad:(UIWebView *) webView
 {
-    self.started = [NSDate date];
+    self.started = [ApigeeNetworkEntry machTime];
     
     if (self.target && [self.target respondsToSelector:@selector(webViewDidStartLoad:)]) {
         [self.target webViewDidStartLoad:webView];
@@ -58,7 +58,7 @@
 
 - (void) webViewDidFinishLoad:(UIWebView *) webView
 {
-    NSDate *ended = [NSDate date];
+    uint64_t ended = [ApigeeNetworkEntry machTime];
     
     if (self.target && [self.target respondsToSelector:@selector(webViewDidFinishLoad:)]) {
         [self.target webViewDidFinishLoad:webView];
@@ -71,7 +71,7 @@
 
 - (void) webView:(UIWebView *) webView didFailLoadWithError:(NSError *) error
 {
-    NSDate *ended = [NSDate date];
+    uint64_t ended = [ApigeeNetworkEntry machTime];
     
     if (self.target && [self.target respondsToSelector:@selector(webView:didFailLoadWithError:)]) {
         [self.target webView:webView didFailLoadWithError:error];

--- a/source/Classes/Services/ApigeeURLConnection.h
+++ b/source/Classes/Services/ApigeeURLConnection.h
@@ -12,7 +12,7 @@
  */
 @interface ApigeeURLConnection : NSURLConnection
 
-@property (strong) NSDate *started;
+@property (assign) uint64_t started;
 
 + (NSURLConnection *) connectionWithRequest:(NSURLRequest *) request delegate:(id < NSURLConnectionDelegate >) delegate;
 + (NSData *) sendSynchronousRequest:(NSURLRequest *) request

--- a/source/Classes/Services/ApigeeURLConnection.m
+++ b/source/Classes/Services/ApigeeURLConnection.m
@@ -28,7 +28,7 @@
                        returningResponse:(NSURLResponse **)response
                                    error:(NSError **)error
 {
-    NSDate *startTime = [NSDate date];
+    uint64_t startTime = [ApigeeNetworkEntry machTime];
     
     NSError *reportingError = nil;
     NSData *responseData;
@@ -43,7 +43,7 @@
                                                                  error:&reportingError];
     }
     
-    NSDate* endTime = [NSDate date];
+    uint64_t endTime = [ApigeeNetworkEntry machTime];
     
     ApigeeNetworkEntry *entry = [[ApigeeNetworkEntry alloc] init];
     [entry populateStartTime:startTime ended:endTime];
@@ -76,7 +76,7 @@
 
 + (void)sendAsynchronousRequest:(NSURLRequest *)request queue:(NSOperationQueue *)queue completionHandler:(void (^)(NSURLResponse*, NSData*, NSError*))handler
 {
-    NSDate *startTime = [NSDate date];
+    uint64_t startTime = [ApigeeNetworkEntry machTime];
     
     [NSURLConnection sendAsynchronousRequest:request
                                        queue:queue
@@ -84,7 +84,7 @@
                                                NSData *data,
                                                NSError *error) {
                                                           
-                               NSDate *endTime = [NSDate date];
+                               uint64_t endTime = [ApigeeNetworkEntry machTime];
                                                           
                                // invoke our caller's completion handler
                                if (handler) {
@@ -122,7 +122,7 @@
 
 - (void) start
 {
-    _started = [NSDate date];
+    _started = [ApigeeNetworkEntry machTime];
     
     [super start];
 }

--- a/source/Classes/Services/NSData+Apigee.m
+++ b/source/Classes/Services/NSData+Apigee.m
@@ -14,9 +14,9 @@
 
 + (NSData*) timedDataWithContentsOfURL:(NSURL *) url options:(NSDataReadingOptions) readOptionsMask error:(NSError **) errorPtr
 {
-    NSDate *start = [NSDate date];
+    uint64_t start = [ApigeeNetworkEntry machTime];
     NSData *data = [NSData dataWithContentsOfURL:url options:readOptionsMask error:errorPtr];
-    NSDate *end = [NSDate date];
+    uint64_t end = [ApigeeNetworkEntry machTime];
     
     ApigeeNetworkEntry *entry = [[ApigeeNetworkEntry alloc] init];
     [entry populateWithURL:url];
@@ -35,9 +35,9 @@
 
 + (NSData*) timedDataWithContentsOfURL:(NSURL *) url
 {
-    NSDate *start = [NSDate date];
+    uint64_t start = [ApigeeNetworkEntry machTime];
     NSData *data = [NSData dataWithContentsOfURL:url];
-    NSDate *end = [NSDate date];
+    uint64_t end = [ApigeeNetworkEntry machTime];
     
     ApigeeNetworkEntry *entry = [[ApigeeNetworkEntry alloc] init];
     [entry populateWithURL:url];
@@ -51,9 +51,9 @@
 
 - (id) initWithTimedContentsOfURL:(NSURL *) url options:(NSDataReadingOptions) readOptionsMask error:(NSError **) errorPtr
 {
-    NSDate *start = [NSDate date];
+    uint64_t start = [ApigeeNetworkEntry machTime];
     NSData *data = [[NSData alloc] initWithContentsOfURL:url options:readOptionsMask error:errorPtr];
-    NSDate *end = [NSDate date];
+    uint64_t end = [ApigeeNetworkEntry machTime];
     
     ApigeeNetworkEntry *entry = [[ApigeeNetworkEntry alloc] init];
     [entry populateWithURL:url];
@@ -72,9 +72,9 @@
 
 - (id) initWithTimedContentsOfURL:(NSURL *) url
 {
-    NSDate *start = [NSDate date];
+    uint64_t start = [ApigeeNetworkEntry machTime];
     NSData *data = [[NSData alloc] initWithContentsOfURL:url];
-    NSDate *end = [NSDate date];
+    uint64_t end = [ApigeeNetworkEntry machTime];
     
     ApigeeNetworkEntry *entry = [[ApigeeNetworkEntry alloc] init];
     [entry populateWithURL:url];
@@ -88,9 +88,9 @@
 
 - (BOOL) timedWriteToURL:(NSURL *)url options:(NSDataWritingOptions)writeOptionsMask error:(NSError **)errorPtr
 {
-    NSDate *start = [NSDate date];
+    uint64_t start = [ApigeeNetworkEntry machTime];
     BOOL result = [self writeToURL:url options:writeOptionsMask error:errorPtr];
-    NSDate *end = [NSDate date];
+    uint64_t end = [ApigeeNetworkEntry machTime];
 
     ApigeeNetworkEntry *entry = [[ApigeeNetworkEntry alloc] init];
     [entry populateWithURL:url];

--- a/source/Classes/Services/NSString+Apigee.m
+++ b/source/Classes/Services/NSString+Apigee.m
@@ -14,9 +14,9 @@
 
 + (NSString*) stringWithTimedContentsOfURL:(NSURL *) url encoding:(NSStringEncoding) enc error:(NSError **) error
 {
-    NSDate *start = [NSDate date];
+    uint64_t start = [ApigeeNetworkEntry machTime];
     NSString *data = [NSString stringWithContentsOfURL:url encoding:enc error:error];
-    NSDate *end = [NSDate date];
+    uint64_t end = [ApigeeNetworkEntry machTime];
     
     ApigeeNetworkEntry *entry = [[ApigeeNetworkEntry alloc] init];
     [entry populateWithURL:url];
@@ -34,9 +34,9 @@
 
 + (NSString*) stringWithTimedContentsOfURL:(NSURL *) url usedEncoding:(NSStringEncoding *) enc error:(NSError **) error
 {
-    NSDate *start = [NSDate date];
+    uint64_t start = [ApigeeNetworkEntry machTime];
     NSString *data = [NSString stringWithContentsOfURL:url usedEncoding:enc error:error];
-    NSDate *end = [NSDate date];
+    uint64_t end = [ApigeeNetworkEntry machTime];
     
     ApigeeNetworkEntry *entry = [[ApigeeNetworkEntry alloc] init];
     [entry populateWithURL:url];
@@ -54,9 +54,9 @@
 
 - (id) initWithTimedContentsOfURL:(NSURL *) url encoding:(NSStringEncoding) enc error:(NSError **) error
 {
-    NSDate *start = [NSDate date];
+    uint64_t start = [ApigeeNetworkEntry machTime];
     NSString *data = [[NSString alloc] initWithContentsOfURL:url encoding:enc error:error];
-    NSDate *end = [NSDate date];
+    uint64_t end = [ApigeeNetworkEntry machTime];
     
     ApigeeNetworkEntry *entry = [[ApigeeNetworkEntry alloc] init];
     [entry populateWithURL:url];
@@ -74,9 +74,9 @@
 
 - (id) initWithTimedContentsOfURL:(NSURL *) url usedEncoding:(NSStringEncoding *) enc error:(NSError **) error
 {
-    NSDate *start = [NSDate date];
+    uint64_t start = [ApigeeNetworkEntry machTime];
     NSString *data = [[NSString alloc] initWithContentsOfURL:url usedEncoding:enc error:error];
-    NSDate *end = [NSDate date];
+    uint64_t end = [ApigeeNetworkEntry machTime];
 
     ApigeeNetworkEntry *entry = [[ApigeeNetworkEntry alloc] init];
     [entry populateWithURL:url];

--- a/source/Classes/Services/NSURLConnection+Apigee.h
+++ b/source/Classes/Services/NSURLConnection+Apigee.h
@@ -98,11 +98,11 @@
 /*!
  @internal
  */
-- (NSDate*)startTime;
+- (uint64_t)startTime;
 
 /*!
  @internal
  */
-- (void)setStartTime:(NSDate*)theStartTime;
+- (void)setStartTime:(uint64_t)theStartTime;
 
 @end


### PR DESCRIPTION
...solute_time) instead of NSDate. The mach time is much more precise and not subject to clock drift errors like NSDate.
