### PR TITLE
Added disconnectEntitiesByName

### DIFF
--- a/source/Classes/AppServices/ApigeeDataClient.h
+++ b/source/Classes/AppServices/ApigeeDataClient.h
@@ -1024,6 +1024,42 @@ typedef void (^ApigeeDataClientCompletionHandler)(ApigeeClientResponse *response
  @param connectorType The collection type for the "from" connecting entity
  @param connectorID The identifier of the "from" connecting entity
  @param connectionType The type of the connection (e.g., "like")
+ @param connecteeType The collection type for the "to" connecting entity
+ @param connecteeID The identifier of the "to" connecting entity
+ @return ApigeeClientResponse instance
+ @see ApigeeClientResponse ApigeeClientResponse
+ @discussion It uses the same parameters and calling rules as connectEntities
+ */
+-(ApigeeClientResponse *)disconnectEntitiesByName:(NSString *)connectorType
+                                connectorID:(NSString *)connectorID
+                                       type:(NSString *)connectionType
+                                connecteeType:(NSString *)connecteeType
+                                connecteeID:(NSString *)connecteeID;
+
+/*!
+ @abstract Asynchronously disconnect two entities
+ @param connectorType The collection type for the "from" connecting entity
+ @param connectorID The identifier of the "from" connecting entity
+ @param connectionType The type of the connection (e.g., "like")
+ @param connecteeType The collection type for the "to" connecting entity
+ @param connecteeID The identifier of the "to" connecting entity
+ @param completionHandler The callback to call when request completes
+ @return ApigeeClientResponse instance
+ @see ApigeeClientResponse ApigeeClientResponse
+ @discussion It uses the same parameters and calling rules as connectEntities
+ */
+-(ApigeeClientResponse *)disconnectEntitiesByName:(NSString *)connectorType
+                                connectorID:(NSString *)connectorID
+                                       type:(NSString *)connectionType
+                                connecteeType:(NSString *)connecteeType
+                                connecteeID:(NSString *)connecteeID
+                          completionHandler:(ApigeeDataClientCompletionHandler)completionHandler;
+
+/*!
+ @abstract Disconnect two entities
+ @param connectorType The collection type for the "from" connecting entity
+ @param connectorID The identifier of the "from" connecting entity
+ @param connectionType The type of the connection (e.g., "like")
  @param connecteeID The identifier of the "to" connecting entity
  @return ApigeeClientResponse instance
  @see ApigeeClientResponse ApigeeClientResponse

--- a/source/Classes/AppServices/ApigeeDataClient.m
+++ b/source/Classes/AppServices/ApigeeDataClient.m
@@ -1524,6 +1524,18 @@ NSString *g_deviceUUID = nil;
     return [self httpTransaction:url op:kApigeeHTTPPost opData:nil completionHandler:completionHandler];
 }
 
+-(ApigeeClientResponse *)disconnectEntitiesByName: (NSString *)connectorType connectorID:(NSString *)connectorID type:(NSString *)connectionType connecteeType:(NSString *)connecteeType connecteeID:(NSString *)connecteeID
+{
+    NSString *url = [self createURL:connectorType append2:connectorID append3:connectionType append4:connecteeType append5:connecteeID];
+    return [self httpTransaction:url op:kApigeeHTTPDelete opData:nil];
+}
+
+-(ApigeeClientResponse *)disconnectEntitiesByName: (NSString *)connectorType connectorID:(NSString *)connectorID type:(NSString *)connectionType connecteeType:(NSString *)connecteeType connecteeID:(NSString *)connecteeID completionHandler:(ApigeeDataClientCompletionHandler)completionHandler
+{
+    NSString *url = [self createURL:connectorType append2:connectorID append3:connectionType append4:connecteeType append5:connecteeID];
+    return [self httpTransaction:url op:kApigeeHTTPDelete opData:nil completionHandler:completionHandler];
+}
+
 -(ApigeeClientResponse *)disconnectEntities: (NSString *)connectorType connectorID:(NSString *)connectorID type:(NSString *)connectionType connecteeID:(NSString *)connecteeID
 {
     NSString *url = [self createURL:connectorType append2:connectorID append3:connectionType append4:connecteeID];


### PR DESCRIPTION
The current disconnectEntities only allowed disconnect based on UUID. This method supports this request:

DELETE /connecting_collection/connecting_entity/relationship/connected_collection/connected_entity
