### PR TITLE
fix a typo so we can get the associated object

### DIFF
--- a/source/Classes/Services/NSURLConnection+Apigee.m
+++ b/source/Classes/Services/NSURLConnection+Apigee.m
@@ -124,7 +124,7 @@ static NSData* NSURLConnection_apigeeSendSynchronousRequestReturningResponseErro
 static ApigeeNSURLConnectionDataDelegateInterceptor* GetConnectionInterceptor(NSURLConnection* connection)
 {
     return (ApigeeNSURLConnectionDataDelegateInterceptor*)
-        objc_getAssociatedObject(connection, KEY_CONNECTION_INTERCEPTOR);
+        objc_getAssociatedObject(connection, &KEY_CONNECTION_INTERCEPTOR);
 }
 
 static void AttachConnectionInterceptor(NSURLConnection* connection,


### PR DESCRIPTION
Use address of a static variable as the key to set/get associated object. Fix the typo here. 
