### PR TITLE
Fixed bug that attempts to use NSUTF8StringEncoding instead of NSASCIIStringEncoding for the post data in api calls.

### DIFF
--- a/source/Classes/AppServices/ApigeeHTTPManager.m
+++ b/source/Classes/AppServices/ApigeeHTTPManager.m
@@ -364,8 +364,11 @@ NSRecursiveLock *g_transactionIDLock = nil;
     if ( opStr )
     {
         // prep the post data
-        NSData *opData = [opStr dataUsingEncoding:NSASCIIStringEncoding allowLossyConversion:YES];
-        
+        NSData *opData = [opStr dataUsingEncoding:NSUTF8StringEncoding allowLossyConversion:YES];
+        if( opData == nil ) {
+            opData = [opStr dataUsingEncoding:NSASCIIStringEncoding allowLossyConversion:YES];
+        }
+
         // make a string that tells the length of the post data. We'll need that for the HTTP header setup
         NSString *opLength = [NSString stringWithFormat:@"%lu", (unsigned long)[opData length]];
         


### PR DESCRIPTION
Fix in reference to this issue https://github.com/apigee/apigee-ios-sdk/issues/101
